### PR TITLE
Fixed problem with method "moved" toIx property

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -161,6 +161,7 @@ export class Sortable {
   moveSortingItem(toIx) {
     const fromIx = this.items.indexOf(this.drag.item);
     this.move(fromIx, toIx);
+    this.toIx = toIx;
   }
   move(fromIx, toIx) {
     if (fromIx !== -1 && toIx !== -1 && fromIx !== toIx) {


### PR DESCRIPTION
Fixed by adding in  moveSortingItem method line that assigns toIx
argumet to class property so it can be visible for moved method.
