### PR TITLE
Selector Scroll Fix and Scroll Demo

### DIFF
--- a/demo/src/app.ts
+++ b/demo/src/app.ts
@@ -8,7 +8,8 @@ export class App {
     config.map([
       { route: ['', 'advanced'], name: 'advanced', moduleId: PLATFORM.moduleName('advanced', 'advanced'), nav: true, title: 'Advanced' },
       { route: 'simple-y', name: 'simple-y', moduleId: PLATFORM.moduleName('simple-y'), nav: true, title: 'Simple - Y' },
-      { route: 'simple-xy', name: 'simple-xy', moduleId: PLATFORM.moduleName('simple-xy'), nav: true, title: 'Simple - XY' }
+      { route: 'simple-xy', name: 'simple-xy', moduleId: PLATFORM.moduleName('simple-xy'), nav: true, title: 'Simple - XY' },
+      { route: 'scroll', name: 'scroll', moduleId: PLATFORM.moduleName('scroll'), nav: true, title: 'Scroll' }
     ]);
     this.router = router;
   }

--- a/demo/src/scroll.html
+++ b/demo/src/scroll.html
@@ -1,0 +1,19 @@
+<template>
+  <div class="table-container">
+    <table>
+      <tbody oa-sortable="items.bind: items; axis.bind: 'y'; allowed-drag-selector.bind: '.lui-icon--handle'; scroll.bind: '.table-container';">
+      <tr
+        oa-sortable-item="item.bind: item;"
+        repeat.for="item of items"
+        draggable="false">
+        <td>
+          <span class="lui-icon lui-icon--large lui-icon--handle"></span>
+        </td>
+        <td>
+          <div>${item.name}</div>
+        </td>
+      </tr>
+    </tbody>
+    </table>
+  </div>
+</template>

--- a/demo/src/scroll.ts
+++ b/demo/src/scroll.ts
@@ -1,0 +1,24 @@
+export class Scroll {
+  public items = [{
+    name: `Lorem ipsum dolor sit amet, mutat ocurreret voluptaria vis et, alii quodsi incorrupte vis in. Eos debet persius pericula ei, in has posse suscipiantur, ius.`,
+    img: `http://lorempixel.com/48/48/sports/1`
+  }, {
+    name: `Lorem ipsum dolor sit amet, cibo ubique ei vim. Pro an porro repudiare sadipscing, vis at mazim detraxit. Cum et solum adipisci persequeris, ex delectus.`,
+    img: `http://lorempixel.com/48/48/sports/2`
+  }, {
+    name: `Lorem ipsum dolor sit amet, eu pro malis vitae, pro no sumo justo blandit. Doming oblique disputationi ex duo, an.`,
+    img: `http://lorempixel.com/48/48/sports/3`
+  }, {
+    name: `Lorem ipsum dolor sit amet, pri ad tacimates forensibus, aperiri meliore mea cu. Vix lucilius imperdiet democritum ne, ut elitr gubergren eam, per at incorrupte reprehendunt. Mnesarchum dissentiunt vis ne.`,
+    img: `http://lorempixel.com/48/48/sports/4`
+  }, {
+    name: `Lorem ipsum dolor sit amet, augue semper nostrum eam id.`,
+    img: `http://lorempixel.com/48/48/sports/5`
+  }, {
+    name: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque ac porttitor mauris. Integer et massa arcu. Fusce tincidunt enim a consequat viverra.`,
+    img: `http://lorempixel.com/48/48/sports/6`
+  }, {
+    name: `Lorem ipsum dolor sit amet, velit mollis porta feugiat, sapien ante gravida arcu, ac tincidunt justo ex a ante.`,
+    img: `http://lorempixel.com/48/48/sports/7`
+  }];
+}

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -288,3 +288,8 @@ td {
 .oa-sorting {
   opacity: 0.3;
 }
+
+.table-container {
+  max-height: 300px;
+  overflow: auto;
+}

--- a/src/auto-scroll.ts
+++ b/src/auto-scroll.ts
@@ -30,10 +30,10 @@ export class AutoScroll {
       if (!this.active) {
         return;
       }
-      if (scrollFrames.x > 0) {
+      if (Math.abs(scrollFrames.x) > 0) {
         scrollElement.scrollLeft += scrollDeltaX;
       }
-      if (scrollFrames.y > 0) {
+      if (Math.abs(scrollFrames.y) > 0) {
         scrollElement.scrollTop += scrollDeltaY;
       }
 

--- a/src/sortable.ts
+++ b/src/sortable.ts
@@ -112,7 +112,7 @@ export class Sortable {
     const { scrollLeft, scrollTop, scrollWidth, scrollHeight } = scrollElement;
     const scrollSpeed = this.scrollSpeed;
     const scrollMaxPos = utils.getScrollMaxPos(this.element, this.rootSortableRect, scrollElement, { scrollLeft, scrollTop, scrollWidth, scrollHeight }, this.scrollRect, window);
-    const scrollDirection = utils.getScrollDirection(this.axis, this.scrollSensitivity, client, this.boundaryRect);
+    const scrollDirection = utils.getScrollDirection(this.axis, this.scrollSensitivity, client, this.scrollRect);
     scrollMaxPos.x = scrollDirection.x === -1 ? 0 : scrollMaxPos.x;
     scrollMaxPos.y = scrollDirection.y === -1 ? 0 : scrollMaxPos.y;
     const scrollFrames = utils.getScrollFrames(scrollDirection, scrollMaxPos, { scrollLeft, scrollTop }, scrollSpeed);


### PR DESCRIPTION
**Issue:** Scrolling wasn’t working correctly when using a selector to use an
element outside of the sortable container.

**Demo of issue:**

[https://ssestrad.github.io/aurelia-sortable-scroll-issue/#/scroll](https://ssestrad.github.io/aurelia-sortable-scroll-issue/#/scroll)

**Demo of fix:**

[https://ssestrad.github.io/aurelia-sortable-scroll-fix/#/scroll](https://ssestrad.github.io/aurelia-sortable-scroll-fix/#/scroll)

The issue was due to using the boundaries of the sortable container instead of the element grabbed from the selector.

There was also another issue where it would not scroll due to the scroll frame boundary being negative.

Also updated the demo to include a scroll demo.